### PR TITLE
Add FAQ and privacy policy pages

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -208,9 +208,14 @@ export default function ArticlesPage() {
               </Link>
             </div>
             <p>&copy; {new Date().getFullYear()} Anastasia's HR Contracting. All rights reserved.</p>
-            <Link href="/privacy-policy" className="text-white hover:text-[#f69358]">
-              Privacy Policy
-            </Link>
+            <div className="flex space-x-4">
+              <Link href="/privacy-policy" className="text-white hover:text-[#f69358]">
+                Privacy Policy
+              </Link>
+              <Link href="/faq" className="text-white hover:text-[#f69358]">
+                FAQ
+              </Link>
+            </div>
           </div>
         </div>
       </footer>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -348,9 +348,14 @@ export default function ContactPage() {
               </Link>
             </div>
             <p>&copy; {new Date().getFullYear()} Anastasia's HR Contracting. All rights reserved.</p>
-            <Link href="/privacy-policy" className="text-white hover:text-[#f69358]">
-              Privacy Policy
-            </Link>
+            <div className="flex space-x-4">
+              <Link href="/privacy-policy" className="text-white hover:text-[#f69358]">
+                Privacy Policy
+              </Link>
+              <Link href="/faq" className="text-white hover:text-[#f69358]">
+                FAQ
+              </Link>
+            </div>
           </div>
         </div>
       </footer>

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 
-export default function ServicesPage() {
+export default function FaqPage() {
   return (
     <div className="flex flex-col min-h-screen bg-[#e7a8b4]">
       <header
@@ -21,7 +21,7 @@ export default function ServicesPage() {
           </Link>
           <nav className="hidden md:flex items-center gap-8">
             <div className="group relative">
-              <Link href="/services" className="text-sm font-medium text-[#133b4c] transition-colors py-2 border-b-2 border-[#133b4c]">
+              <Link href="/services" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR SERVICES
               </Link>
               <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-white shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
@@ -66,18 +66,7 @@ export default function ServicesPage() {
             </Link>
           </nav>
           <Button variant="outline" size="icon" className="md:hidden">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-5 w-5"
-            >
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-menu">
               <line x1="4" x2="20" y1="12" y2="12" />
               <line x1="4" x2="20" y1="6" y2="6" />
               <line x1="4" x2="20" y1="18" y2="18" />
@@ -89,7 +78,7 @@ export default function ServicesPage() {
       <div className="w-full">
         <Image
           src="/anastasias-hr-contracting-logo.png"
-          alt="Our Services"
+          alt="FAQ"
           width={1920}
           height={400}
           className="w-full object-cover"
@@ -100,18 +89,24 @@ export default function ServicesPage() {
       <main className="flex-1">
         <section className="w-full py-16 md:py-24 bg-[#e7a8b4]">
           <div className="container px-4 md:px-6">
-            <div className="max-w-3xl mx-auto text-center space-y-6">
-              <h1 className="text-4xl md:text-5xl font-bold text-[#133b4c]">Our Services</h1>
-              <p className="text-lg text-[#41184a]">Coming soon.</p>
+            <div className="max-w-3xl mx-auto space-y-6">
+              <h1 className="text-4xl md:text-5xl font-bold text-[#133b4c] text-center">Frequently Asked Questions</h1>
+              <div className="space-y-4 text-[#41184a]">
+                <div>
+                  <h2 className="font-semibold">What services do you offer?</h2>
+                  <p>We provide comprehensive HR consulting tailored to creative and Indigenous-focused organizations.</p>
+                </div>
+                <div>
+                  <h2 className="font-semibold">How can I contact you?</h2>
+                  <p>You can reach us anytime through the contact form on our website or by phone.</p>
+                </div>
+              </div>
             </div>
           </div>
         </section>
       </main>
 
-      <footer
-        className="text-white bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-footer.svg')" }}
-      >
+      <footer className="text-white bg-cover bg-center" style={{ backgroundImage: "url('/website-footer.svg')" }}>
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">
             <div>
@@ -138,70 +133,26 @@ export default function ServicesPage() {
           <div className="border-t border-white/20 mt-8 pt-8 flex flex-col items-center gap-4 md:flex-row md:justify-between">
             <div className="flex space-x-4">
               <Link href="https://linkedin.com" className="text-white hover:text-[#f69358]">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="h-5 w-5"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
                   <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
                   <rect width="4" height="12" x="2" y="9" />
                   <circle cx="4" cy="4" r="2" />
                 </svg>
               </Link>
               <Link href="https://facebook.com" className="text-white hover:text-[#f69358]">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="h-5 w-5"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
                   <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z" />
                 </svg>
               </Link>
               <Link href="https://instagram.com" className="text-white hover:text-[#f69358]">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="h-5 w-5"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
                   <rect width="20" height="20" x="2" y="2" rx="5" ry="5" />
                   <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
                   <line x1="17.5" x2="17.51" y1="6.5" y2="6.5" />
                 </svg>
               </Link>
               <Link href="https://pinterest.com" className="text-white hover:text-[#f69358]">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="h-5 w-5"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
                   <line x1="12" x2="12" y1="8" y2="16" />
                   <line x1="8" x2="16" y1="12" y2="12" />
                 </svg>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -543,9 +543,14 @@ export default function Home() {
               </Link>
             </div>
             <p>&copy; {new Date().getFullYear()} Anastasia's HR Contracting. All rights reserved.</p>
-            <Link href="/privacy-policy" className="text-white hover:text-[#f69358]">
-              Privacy Policy
-            </Link>
+            <div className="flex space-x-4">
+              <Link href="/privacy-policy" className="text-white hover:text-[#f69358]">
+                Privacy Policy
+              </Link>
+              <Link href="/faq" className="text-white hover:text-[#f69358]">
+                FAQ
+              </Link>
+            </div>
           </div>
         </div>
       </footer>

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 
-export default function ServicesPage() {
+export default function PrivacyPolicyPage() {
   return (
     <div className="flex flex-col min-h-screen bg-[#e7a8b4]">
       <header
@@ -21,7 +21,7 @@ export default function ServicesPage() {
           </Link>
           <nav className="hidden md:flex items-center gap-8">
             <div className="group relative">
-              <Link href="/services" className="text-sm font-medium text-[#133b4c] transition-colors py-2 border-b-2 border-[#133b4c]">
+              <Link href="/services" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR SERVICES
               </Link>
               <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-white shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
@@ -66,18 +66,7 @@ export default function ServicesPage() {
             </Link>
           </nav>
           <Button variant="outline" size="icon" className="md:hidden">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-5 w-5"
-            >
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-menu">
               <line x1="4" x2="20" y1="12" y2="12" />
               <line x1="4" x2="20" y1="6" y2="6" />
               <line x1="4" x2="20" y1="18" y2="18" />
@@ -86,32 +75,18 @@ export default function ServicesPage() {
         </div>
       </header>
 
-      <div className="w-full">
-        <Image
-          src="/anastasias-hr-contracting-logo.png"
-          alt="Our Services"
-          width={1920}
-          height={400}
-          className="w-full object-cover"
-          priority
-        />
-      </div>
-
       <main className="flex-1">
         <section className="w-full py-16 md:py-24 bg-[#e7a8b4]">
           <div className="container px-4 md:px-6">
-            <div className="max-w-3xl mx-auto text-center space-y-6">
-              <h1 className="text-4xl md:text-5xl font-bold text-[#133b4c]">Our Services</h1>
-              <p className="text-lg text-[#41184a]">Coming soon.</p>
+            <div className="max-w-3xl mx-auto space-y-6 text-center">
+              <h1 className="text-4xl md:text-5xl font-bold text-[#133b4c]">Privacy Policy</h1>
+              <p className="text-[#41184a]">This page will contain our privacy policy information.</p>
             </div>
           </div>
         </section>
       </main>
 
-      <footer
-        className="text-white bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-footer.svg')" }}
-      >
+      <footer className="text-white bg-cover bg-center" style={{ backgroundImage: "url('/website-footer.svg')" }}>
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">
             <div>
@@ -138,70 +113,26 @@ export default function ServicesPage() {
           <div className="border-t border-white/20 mt-8 pt-8 flex flex-col items-center gap-4 md:flex-row md:justify-between">
             <div className="flex space-x-4">
               <Link href="https://linkedin.com" className="text-white hover:text-[#f69358]">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="h-5 w-5"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
                   <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
                   <rect width="4" height="12" x="2" y="9" />
                   <circle cx="4" cy="4" r="2" />
                 </svg>
               </Link>
               <Link href="https://facebook.com" className="text-white hover:text-[#f69358]">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="h-5 w-5"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
                   <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z" />
                 </svg>
               </Link>
               <Link href="https://instagram.com" className="text-white hover:text-[#f69358]">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="h-5 w-5"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
                   <rect width="20" height="20" x="2" y="2" rx="5" ry="5" />
                   <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
                   <line x1="17.5" x2="17.51" y1="6.5" y2="6.5" />
                 </svg>
               </Link>
               <Link href="https://pinterest.com" className="text-white hover:text-[#f69358]">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="h-5 w-5"
-                >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
                   <line x1="12" x2="12" y1="8" y2="16" />
                   <line x1="8" x2="16" y1="12" y2="12" />
                 </svg>

--- a/app/story/page.tsx
+++ b/app/story/page.tsx
@@ -208,9 +208,14 @@ export default function StoryPage() {
               </Link>
             </div>
             <p>&copy; {new Date().getFullYear()} Anastasia's HR Contracting. All rights reserved.</p>
-            <Link href="/privacy-policy" className="text-white hover:text-[#f69358]">
-              Privacy Policy
-            </Link>
+            <div className="flex space-x-4">
+              <Link href="/privacy-policy" className="text-white hover:text-[#f69358]">
+                Privacy Policy
+              </Link>
+              <Link href="/faq" className="text-white hover:text-[#f69358]">
+                FAQ
+              </Link>
+            </div>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- add placeholder FAQ page with hero image
- add privacy policy page
- link FAQ next to Privacy Policy in footer across all pages

## Testing
- `npx next build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853566d8d34832fbe115778d953f28e