### PR TITLE
Add resume support service, update styles

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -24,7 +24,7 @@ export default function ArticlesPage() {
               <Link href="/services" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR SERVICES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/services#consulting" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Comprehensive HR Consulting</Link>
                   <Link href="/services#recruitment" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Full-Cycle Recruitment</Link>
@@ -34,6 +34,7 @@ export default function ArticlesPage() {
                   <Link href="/services#employee-relations" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Employee Relations</Link>
                   <Link href="/services#training" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Training & Development</Link>
                   <Link href="/services#individual-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Support for Individuals</Link>
+                  <Link href="/services#resume-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Resume, Cover Letter & Networking Support</Link>
                 </div>
               </div>
             </div>
@@ -41,7 +42,7 @@ export default function ArticlesPage() {
               <Link href="/story" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR STORY
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/story#who-we-are" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Who We Are</Link>
                   <Link href="/story#mission" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Our Mission</Link>
@@ -54,7 +55,7 @@ export default function ArticlesPage() {
               <Link href="/articles" className="text-sm font-medium text-[#133b4c] transition-colors py-2 border-b-2 border-[#133b4c]">
                 ARTICLES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/articles#cultural-hr" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">The Power of Culturally-Informed HR</Link>
                   <Link href="/articles#building-teams" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Building Better Teams: A Guide for Leaders</Link>
@@ -92,7 +93,7 @@ export default function ArticlesPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Articles"
           width={1920}
-          height={200}
+          height={100}
           className="w-full object-cover"
           priority
         />
@@ -109,7 +110,7 @@ export default function ArticlesPage() {
           </div>
         </section>
 
-        <section id="cultural-hr" className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section id="cultural-hr" className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
               <h2 className="text-3xl font-bold text-[#133b4c]">The Power of Culturally-Informed HR</h2>
@@ -131,7 +132,7 @@ export default function ArticlesPage() {
           </div>
         </section>
 
-        <section id="navigating-change" className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section id="navigating-change" className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
               <h2 className="text-3xl font-bold text-[#133b4c]">Navigating Change: HR Strategies for Evolving Organizations</h2>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -27,7 +27,7 @@ export default function ContactPage() {
               <Link href="/services" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR SERVICES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/services#consulting" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Comprehensive HR Consulting</Link>
                   <Link href="/services#recruitment" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Full-Cycle Recruitment</Link>
@@ -37,6 +37,7 @@ export default function ContactPage() {
                   <Link href="/services#employee-relations" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Employee Relations</Link>
                   <Link href="/services#training" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Training & Development</Link>
                   <Link href="/services#individual-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Support for Individuals</Link>
+                  <Link href="/services#resume-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Resume, Cover Letter & Networking Support</Link>
                 </div>
               </div>
             </div>
@@ -44,7 +45,7 @@ export default function ContactPage() {
               <Link href="/story" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR STORY
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/story#who-we-are" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Who We Are</Link>
                   <Link href="/story#mission" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Our Mission</Link>
@@ -57,7 +58,7 @@ export default function ContactPage() {
               <Link href="/articles" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 ARTICLES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/articles#cultural-hr" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">The Power of Culturally-Informed HR</Link>
                   <Link href="/articles#building-teams" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Building Better Teams: A Guide for Leaders</Link>
@@ -95,7 +96,7 @@ export default function ContactPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Contact Us"
           width={1920}
-          height={200}
+          height={100}
           className="w-full object-cover"
           priority
         />
@@ -113,7 +114,7 @@ export default function ContactPage() {
           </div>
         </section>
 
-        <section className="w-full py-16 bg-[#baece4]">
+        <section className="w-full py-16 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="grid gap-12 lg:grid-cols-2">
               <div className="space-y-8">
@@ -178,7 +179,7 @@ export default function ContactPage() {
                         >
                           First name
                         </label>
-                        <Input id="first-name" placeholder="Enter your first name" className="bg-[#baece4]" />
+                        <Input id="first-name" placeholder="Enter your first name" className="bg-[#fcf8ed]" />
                       </div>
                       <div className="space-y-2">
                         <label
@@ -187,7 +188,7 @@ export default function ContactPage() {
                         >
                           Last name
                         </label>
-                        <Input id="last-name" placeholder="Enter your last name" className="bg-[#baece4]" />
+                        <Input id="last-name" placeholder="Enter your last name" className="bg-[#fcf8ed]" />
                       </div>
                     </div>
                     <div className="space-y-2">
@@ -197,7 +198,7 @@ export default function ContactPage() {
                       >
                         Email
                       </label>
-                      <Input id="email" type="email" placeholder="Enter your email" className="bg-[#baece4]" />
+                      <Input id="email" type="email" placeholder="Enter your email" className="bg-[#fcf8ed]" />
                     </div>
                     <div className="space-y-2">
                       <label
@@ -206,7 +207,7 @@ export default function ContactPage() {
                       >
                         Phone
                       </label>
-                      <Input id="phone" type="tel" placeholder="Enter your phone number" className="bg-[#baece4]" />
+                      <Input id="phone" type="tel" placeholder="Enter your phone number" className="bg-[#fcf8ed]" />
                     </div>
                     <div className="space-y-2">
                       <label
@@ -215,7 +216,7 @@ export default function ContactPage() {
                       >
                         Subject
                       </label>
-                      <Input id="subject" placeholder="What is this regarding?" className="bg-[#baece4]" />
+                      <Input id="subject" placeholder="What is this regarding?" className="bg-[#fcf8ed]" />
                     </div>
                     <div className="space-y-2">
                       <label
@@ -224,7 +225,7 @@ export default function ContactPage() {
                       >
                         Message
                       </label>
-                      <Textarea id="message" placeholder="Enter your message" className="min-h-[120px] bg-[#baece4]" />
+                      <Textarea id="message" placeholder="Enter your message" className="min-h-[120px] bg-[#fcf8ed]" />
                     </div>
                     <Button className="w-full bg-[#133b4c] hover:bg-[#4a7e1c] text-white">Send Message</Button>
                   </form>

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -24,7 +24,7 @@ export default function FaqPage() {
               <Link href="/services" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR SERVICES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/services#consulting" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Comprehensive HR Consulting</Link>
                   <Link href="/services#recruitment" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Full-Cycle Recruitment</Link>
@@ -34,6 +34,7 @@ export default function FaqPage() {
                   <Link href="/services#employee-relations" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Employee Relations</Link>
                   <Link href="/services#training" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Training & Development</Link>
                   <Link href="/services#individual-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Support for Individuals</Link>
+                  <Link href="/services#resume-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Resume, Cover Letter & Networking Support</Link>
                 </div>
               </div>
             </div>
@@ -41,7 +42,7 @@ export default function FaqPage() {
               <Link href="/story" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR STORY
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/story#who-we-are" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Who We Are</Link>
                   <Link href="/story#mission" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Our Mission</Link>
@@ -54,7 +55,7 @@ export default function FaqPage() {
               <Link href="/articles" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 ARTICLES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/articles#cultural-hr" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">The Power of Culturally-Informed HR</Link>
                   <Link href="/articles#building-teams" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Building Better Teams: A Guide for Leaders</Link>
@@ -81,7 +82,7 @@ export default function FaqPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="FAQ"
           width={1920}
-          height={200}
+          height={100}
           className="w-full object-cover"
           priority
         />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
               >
                 OUR SERVICES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/services#consulting" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Comprehensive HR Consulting</Link>
                   <Link href="/services#recruitment" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Full-Cycle Recruitment</Link>
@@ -38,6 +38,7 @@ export default function Home() {
                   <Link href="/services#employee-relations" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Employee Relations</Link>
                   <Link href="/services#training" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Training & Development</Link>
                   <Link href="/services#individual-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Support for Individuals</Link>
+                  <Link href="/services#resume-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Resume, Cover Letter & Networking Support</Link>
                 </div>
               </div>
             </div>
@@ -48,7 +49,7 @@ export default function Home() {
               >
                 OUR STORY
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/story#who-we-are" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">
                     Who We Are
@@ -72,7 +73,7 @@ export default function Home() {
               >
                 ARTICLES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/articles#cultural-hr" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">
                     The Power of Culturally-Informed HR
@@ -122,7 +123,7 @@ export default function Home() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Anastasia's HR Contracting"
           width={1920}
-          height={300}
+          height={150}
           className="w-full object-cover"
           priority
         />
@@ -145,7 +146,7 @@ export default function Home() {
           </div>
         </section>
 
-        <section className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="grid gap-12 lg:grid-cols-2 items-center">
               <div className="space-y-6">
@@ -220,7 +221,7 @@ export default function Home() {
           </div>
         </section>
 
-        <section className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="text-center mb-12">
               <h2 className="text-3xl font-bold text-[#133b4c]">Our Services</h2>
@@ -280,6 +281,14 @@ export default function Home() {
                 <p className="text-[#41184a]">
                   Whether you need resume guidance, mock interviews, or personalized HR advice—we’re here for individuals
                   navigating job transitions and workplace challenges.
+                </p>
+              </div>
+              <div className="bg-[#e7a8b4] p-6 rounded-lg shadow-sm border border-[#bcb5aa]">
+                <h3 className="text-xl font-bold text-[#133b4c] mb-3">Resume, Cover Letter & Networking Support</h3>
+                <p className="text-[#41184a]">
+                  Craft compelling career documents and build the confidence to connect. We help individuals create tailored resumes,
+                  write impactful cover letters, and develop effective networking strategies—whether you’re entering the workforce,
+                  making a career shift, or preparing for a new opportunity.
                 </p>
               </div>
             </div>
@@ -402,7 +411,7 @@ export default function Home() {
           </div>
         </section>
 
-        <section className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto text-center space-y-6">
               <h2 className="text-3xl font-bold text-[#133b4c]">Commitment to Reconciliation</h2>
@@ -471,7 +480,7 @@ export default function Home() {
               </p>
               <div>
                 <Link href="https://calendly.com/anastasias-hr/consultation" target="_blank" rel="noopener noreferrer">
-                  <Button className="bg-[#baece4] text-[#133b4c] hover:bg-[#e7a8b4]">Book Now</Button>
+                  <Button className="bg-[#fcf8ed] text-[#133b4c] hover:bg-[#e7a8b4]">Book Now</Button>
                 </Link>
               </div>
               <p className="text-sm pt-8">

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -24,7 +24,7 @@ export default function PrivacyPolicyPage() {
               <Link href="/services" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR SERVICES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/services#consulting" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Comprehensive HR Consulting</Link>
                   <Link href="/services#recruitment" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Full-Cycle Recruitment</Link>
@@ -34,6 +34,7 @@ export default function PrivacyPolicyPage() {
                   <Link href="/services#employee-relations" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Employee Relations</Link>
                   <Link href="/services#training" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Training & Development</Link>
                   <Link href="/services#individual-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Support for Individuals</Link>
+                  <Link href="/services#resume-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Resume, Cover Letter & Networking Support</Link>
                 </div>
               </div>
             </div>
@@ -41,7 +42,7 @@ export default function PrivacyPolicyPage() {
               <Link href="/story" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR STORY
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/story#who-we-are" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Who We Are</Link>
                   <Link href="/story#mission" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Our Mission</Link>
@@ -54,7 +55,7 @@ export default function PrivacyPolicyPage() {
               <Link href="/articles" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 ARTICLES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/articles#cultural-hr" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">The Power of Culturally-Informed HR</Link>
                   <Link href="/articles#building-teams" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Building Better Teams: A Guide for Leaders</Link>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -24,7 +24,7 @@ export default function ServicesPage() {
               <Link href="/services" className="text-sm font-medium text-[#133b4c] transition-colors py-2 border-b-2 border-[#133b4c]">
                 OUR SERVICES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/services#consulting" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Comprehensive HR Consulting</Link>
                   <Link href="/services#recruitment" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Full-Cycle Recruitment</Link>
@@ -34,6 +34,7 @@ export default function ServicesPage() {
                   <Link href="/services#employee-relations" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Employee Relations</Link>
                   <Link href="/services#training" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Training & Development</Link>
                   <Link href="/services#individual-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Support for Individuals</Link>
+                  <Link href="/services#resume-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Resume, Cover Letter & Networking Support</Link>
                 </div>
               </div>
             </div>
@@ -41,7 +42,7 @@ export default function ServicesPage() {
               <Link href="/story" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR STORY
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/story#who-we-are" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Who We Are</Link>
                   <Link href="/story#mission" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Our Mission</Link>
@@ -54,7 +55,7 @@ export default function ServicesPage() {
               <Link href="/articles" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 ARTICLES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/articles#cultural-hr" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">The Power of Culturally-Informed HR</Link>
                   <Link href="/articles#building-teams" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Building Better Teams: A Guide for Leaders</Link>
@@ -92,7 +93,7 @@ export default function ServicesPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Our Services"
           width={1920}
-          height={200}
+          height={100}
           className="w-full object-cover"
           priority
         />
@@ -110,7 +111,7 @@ export default function ServicesPage() {
           </div>
         </section>
 
-        <section id="consulting" className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section id="consulting" className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
               <h2 className="text-3xl font-bold text-[#133b4c]">Comprehensive HR Consulting</h2>
@@ -133,7 +134,7 @@ export default function ServicesPage() {
           </div>
         </section>
 
-        <section id="policy" className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section id="policy" className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
               <h2 className="text-3xl font-bold text-[#133b4c]">HR Policy & Process Development</h2>
@@ -157,7 +158,7 @@ export default function ServicesPage() {
           </div>
         </section>
 
-        <section id="culture" className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section id="culture" className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
               <h2 className="text-3xl font-bold text-[#133b4c]">People & Culture Consulting</h2>
@@ -181,7 +182,7 @@ export default function ServicesPage() {
           </div>
         </section>
 
-        <section id="training" className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section id="training" className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
               <h2 className="text-3xl font-bold text-[#133b4c]">Training & Development Programs</h2>
@@ -196,6 +197,22 @@ export default function ServicesPage() {
           </div>
         </section>
 
+        <section id="resume-support" className="w-full py-16 md:py-24 bg-[#e7a8b4]">
+          <div className="container px-4 md:px-6">
+            <div className="max-w-3xl mx-auto space-y-4">
+              <h2 className="text-3xl font-bold text-[#133b4c]">Resume, Cover Letter & Networking Support</h2>
+              <p className="text-[#41184a]">A strong first impression can open the door to career-changing opportunities. Whether you're entering the workforce, transitioning industries, or aiming for the next level in your career, we offer personalized support to help you stand out—on paper and in person.</p>
+              <p className="text-[#41184a]">We work closely with individuals to develop professional tools that reflect their authentic voice and unique value:</p>
+              <ul className="list-disc list-inside space-y-2 text-[#41184a]">
+                <li><strong>Resume Writing & Optimization</strong> – From entry-level to executive, we help you craft resumes that are clear, tailored, and aligned with industry standards—highlighting your strengths and relevant experience.</li>
+                <li><strong>Cover Letter Development</strong> – We guide you in writing thoughtful, engaging cover letters that connect your personal story to the role you're applying for—helping you go beyond templates and generic intros.</li>
+                <li><strong>Networking & Outreach Coaching</strong> – Building the right connections can be just as important as submitting the perfect application. We offer guidance on how to network with confidence—online, in person, and within your industry—so you can access the opportunities that don’t always get posted.</li>
+              </ul>
+              <p className="text-[#41184a]">Our approach is empathetic, practical, and grounded in the belief that everyone deserves support in building their career with confidence and clarity.</p>
+            </div>
+          </div>
+        </section>
+
         <section id="individual-support" className="w-full py-16 md:py-24 bg-[#e7a8b4]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
@@ -206,7 +223,7 @@ export default function ServicesPage() {
           </div>
         </section>
 
-        <section className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4 text-center">
               <h2 className="text-3xl font-bold text-[#133b4c]">Let’s Build Together</h2>

--- a/app/story/page.tsx
+++ b/app/story/page.tsx
@@ -24,7 +24,7 @@ export default function StoryPage() {
               <Link href="/services" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 OUR SERVICES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/services#consulting" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Comprehensive HR Consulting</Link>
                   <Link href="/services#recruitment" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Full-Cycle Recruitment</Link>
@@ -34,6 +34,7 @@ export default function StoryPage() {
                   <Link href="/services#employee-relations" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Employee Relations</Link>
                   <Link href="/services#training" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Training & Development</Link>
                   <Link href="/services#individual-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Support for Individuals</Link>
+                  <Link href="/services#resume-support" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Resume, Cover Letter & Networking Support</Link>
                 </div>
               </div>
             </div>
@@ -41,7 +42,7 @@ export default function StoryPage() {
               <Link href="/story" className="text-sm font-medium text-[#133b4c] transition-colors py-2 border-b-2 border-[#133b4c]">
                 OUR STORY
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/story#who-we-are" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Who We Are</Link>
                   <Link href="/story#mission" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Our Mission</Link>
@@ -54,7 +55,7 @@ export default function StoryPage() {
               <Link href="/articles" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2">
                 ARTICLES
               </Link>
-              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#baece4] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
+              <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
                   <Link href="/articles#cultural-hr" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">The Power of Culturally-Informed HR</Link>
                   <Link href="/articles#building-teams" className="block text-sm text-[#41184a] hover:text-[#133b4c] py-1">Building Better Teams: A Guide for Leaders</Link>
@@ -92,7 +93,7 @@ export default function StoryPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Our Story"
           width={1920}
-          height={200}
+          height={100}
           className="w-full object-cover"
           priority
         />
@@ -107,7 +108,7 @@ export default function StoryPage() {
           </div>
         </section>
 
-        <section id="who-we-are" className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section id="who-we-are" className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
               <h2 className="text-3xl font-bold text-[#133b4c]">Who We Are</h2>
@@ -133,7 +134,7 @@ export default function StoryPage() {
           </div>
         </section>
 
-        <section id="values" className="w-full py-16 md:py-24 bg-[#baece4]">
+        <section id="values" className="w-full py-16 md:py-24 bg-[#fcf8ed]">
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto space-y-4">
               <h2 className="text-3xl font-bold text-[#133b4c]">Our Values</h2>


### PR DESCRIPTION
## Summary
- shrink hero images for each page
- change background color from `#baece4` to `#fcf8ed`
- add Resume, Cover Letter & Networking Support card on home
- add full Resume, Cover Letter & Networking Support section on services page
- include new service link in all Services menu drop-downs

## Testing
- `npm run lint` *(fails: next not found)*
- `npm ci` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6853898b1e08832f9858ea6f3db6bcd8