### PR TITLE
Reduce topper images and update FAQ

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -93,7 +93,7 @@ export default function ArticlesPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Articles"
           width={1920}
-          height={100}
+          height={80}
           className="w-full object-cover"
           priority
         />

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -96,7 +96,7 @@ export default function ContactPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Contact Us"
           width={1920}
-          height={100}
+          height={80}
           className="w-full object-cover"
           priority
         />

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -82,7 +82,7 @@ export default function FaqPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="FAQ"
           width={1920}
-          height={100}
+          height={80}
           className="w-full object-cover"
           priority
         />
@@ -96,11 +96,46 @@ export default function FaqPage() {
               <div className="space-y-4 text-[#41184a]">
                 <div>
                   <h2 className="font-semibold">What services do you offer?</h2>
-                  <p>We provide comprehensive HR consulting tailored to creative and Indigenous-focused organizations.</p>
+                  <p>
+                    We provide comprehensive HR consulting, full-cycle recruitment,
+                    HR policy &amp; process development, HRIS implementation,
+                    people &amp; culture consulting, employee relations,
+                    training &amp; development, and individual support such as
+                    resume, cover letter &amp; networking assistance.
+                  </p>
                 </div>
                 <div>
-                  <h2 className="font-semibold">How can I contact you?</h2>
-                  <p>You can reach us anytime through the contact form on our website or by phone.</p>
+                  <h2 className="font-semibold">Where are you located and do you work remotely?</h2>
+                  <p>Based in Vancouver, Canada, we support remote, hybrid, and in-person teams wherever you are.</p>
+                </div>
+                <div>
+                  <h2 className="font-semibold">How can I get started?</h2>
+                  <p>
+                    Reach out through our contact form or email, or book a free
+                    discovery call using the link on our homepage.
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-semibold">What is your mission?</h2>
+                  <p>
+                    We create workplaces where people feel valued by removing
+                    obstacles and fostering inclusive cultures.
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-semibold">What values guide your work?</h2>
+                  <p>
+                    Our values include respect, integrity, inclusion, innovation,
+                    collaboration, and empowerment.
+                  </p>
+                </div>
+                <div>
+                  <h2 className="font-semibold">What makes your approach unique?</h2>
+                  <p>
+                    Our consulting is culturally informed and grounded in real
+                    experience with a commitment to reconciliation and community
+                    partnership.
+                  </p>
                 </div>
               </div>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,7 +123,7 @@ export default function Home() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Anastasia's HR Contracting"
           width={1920}
-          height={150}
+          height={80}
           className="w-full object-cover"
           priority
         />

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -93,7 +93,7 @@ export default function ServicesPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Our Services"
           width={1920}
-          height={100}
+          height={80}
           className="w-full object-cover"
           priority
         />

--- a/app/story/page.tsx
+++ b/app/story/page.tsx
@@ -93,7 +93,7 @@ export default function StoryPage() {
           src="/anastasias-hr-contracting-logo.png"
           alt="Our Story"
           width={1920}
-          height={100}
+          height={80}
           className="w-full object-cover"
           priority
         />


### PR DESCRIPTION
## Summary
- resize page topper images to height 80 for consistent styling
- expand FAQ section with additional questions summarising site content

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: asks interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68538b3526f4832fa886bb637302d835