### PR TITLE
Audit readiness for production

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,10 +22,6 @@ export const metadata = {
     locale: 'en_CA',
     type: 'website',
   },
-  viewport: {
-    width: 'device-width',
-    initialScale: 1,
-  },
   generator: 'v0.dev',
   icons: {
     icon: '/favicon/favicon.ico',
@@ -34,6 +30,11 @@ export const metadata = {
     other: [{ rel: 'mask-icon', url: '/favicon/favicon.svg' }],
   },
   manifest: '/favicon/site.webmanifest'
+}
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- move viewport settings to `export const viewport`
- maintain per Next.js 14 rules

## Testing
- `npm run build`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6853907e8914832fb33aa863d5713dcd