### PR TITLE
Add basic i18next setup with French

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import "@/app/globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
+import I18nProvider from "@/components/i18n-provider"
 
 export const metadata = {
   title: "Anastasia's HR Contracting",
@@ -45,9 +46,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-          {children}
-        </ThemeProvider>
+        <I18nProvider>
+          <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+            {children}
+          </ThemeProvider>
+        </I18nProvider>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,13 @@
+'use client'
 import Link from "next/link"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { Facebook, Instagram, Linkedin, PinIcon as Pinterest } from "lucide-react"
 import CurrentYear from "@/components/current-year"
+import { useTranslation } from "react-i18next"
 
 export default function Home() {
+  const { t } = useTranslation()
   return (
     <div className="flex flex-col min-h-screen bg-[#e7a8b4]">
       <header
@@ -27,7 +30,7 @@ export default function Home() {
                 href="/services"
                 className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2"
               >
-                OUR SERVICES
+                {t('our_services')}
               </Link>
               <div className="absolute left-0 top-full mt-2 w-60 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
@@ -48,7 +51,7 @@ export default function Home() {
                 href="/story"
                 className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2"
               >
-                OUR STORY
+                {t('our_story')}
               </Link>
               <div className="absolute left-0 top-full mt-2 w-48 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
@@ -72,7 +75,7 @@ export default function Home() {
                 href="/articles"
                 className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors py-2"
               >
-                ARTICLES
+                {t('articles')}
               </Link>
               <div className="absolute left-0 top-full mt-2 w-64 rounded-md bg-[#fcf8ed] shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all">
                 <div className="p-4 space-y-2">
@@ -95,7 +98,7 @@ export default function Home() {
               </div>
             </div>
             <Link href="/contact" className="text-sm font-medium text-[#41184a] hover:text-[#133b4c] transition-colors">
-              CONTACT US
+              {t('contact_us')}
             </Link>
           </nav>
           <Button
@@ -140,7 +143,7 @@ export default function Home() {
           <div className="container px-4 md:px-6">
             <div className="max-w-3xl mx-auto text-center space-y-6">
               <h1 className="text-4xl md:text-5xl font-bold text-[#133b4c]">
-                Designing Workplaces Where People Thrive
+                {t('designing_workplaces')}
               </h1>
               <p className="text-lg text-[#41184a] leading-relaxed">
                 At Anastasia's HR Contracting, we know that behind every successful business is a tapestry of unique
@@ -526,7 +529,7 @@ export default function Home() {
             </div>
             <div className="md:text-right">
               <h2 className="text-2xl font-bold mb-4">Anastasia's HR Contracting</h2>
-              <p className="mb-6">Designing Workplaces Where People Thrive</p>
+              <p className="mb-6">{t('designing_workplaces')}</p>
               <div className="space-y-2">
                 <p>Email: info@yourdomain.com</p>
                 <p>Phone: 1-(778)-773-55213</p>

--- a/components/i18n-provider.tsx
+++ b/components/i18n-provider.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '@/lib/i18n'
+
+export default function I18nProvider({ children }: { children: React.ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,25 @@
+'use client'
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+import en from '../public/locales/en/common.json'
+import fr from '../public/locales/fr/common.json'
+
+if (!i18n.isInitialized) {
+  i18n
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+      resources: {
+        en: { translation: en },
+        fr: { translation: fr },
+      },
+      fallbackLng: 'en',
+      interpolation: { escapeValue: false },
+      detection: {
+        order: ['navigator', 'htmlTag'],
+      },
+    })
+}
+
+export default i18n

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,8 @@
         "cmdk": "1.0.4",
         "date-fns": "4.1.0",
         "embla-carousel-react": "8.5.1",
+        "i18next": "^23.11.2",
+        "i18next-browser-languagedetector": "^7.1.0",
         "input-otp": "1.4.1",
         "lucide-react": "^0.454.0",
         "next": "15.2.4",
@@ -50,6 +52,7 @@
         "react-day-picker": "8.10.1",
         "react-dom": "^19",
         "react-hook-form": "^7.54.1",
+        "react-i18next": "^15.5.3",
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.0",
         "sonner": "^1.7.1",
@@ -2987,6 +2990,47 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.2.tgz",
+      "integrity": "sha512-6b7r75uIJDWCcCflmbof+sJ94k9UQO4X0YR62oUfqGI/GjCLVzlCwu8TFdRZIqVLzWbzNcmkmhfqKEr4TLz4HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/input-otp": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.1.tgz",
@@ -3710,6 +3754,32 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "15.5.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.3.tgz",
+      "integrity": "sha512-ypYmOKOnjqPEJZO4m1BI0kS8kWqkBNsKYyhVUfij0gvjy9xJNoG/VcGkxq5dRlVwzmrmY1BQMAmpbbUBLwC4Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -4489,6 +4559,15 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,10 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "i18next": "^23.11.2",
+    "react-i18next": "^15.5.3",
+    "i18next-browser-languagedetector": "^7.1.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,7 @@
+{
+  "our_services": "OUR SERVICES",
+  "our_story": "OUR STORY",
+  "articles": "ARTICLES",
+  "contact_us": "CONTACT US",
+  "designing_workplaces": "Designing Workplaces Where People Thrive"
+}

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,0 +1,7 @@
+{
+  "our_services": "NOS SERVICES",
+  "our_story": "NOTRE HISTOIRE",
+  "articles": "ARTICLES",
+  "contact_us": "CONTACTEZ-NOUS",
+  "designing_workplaces": "Concevoir des lieux de travail où les gens s'épanouissent"
+}


### PR DESCRIPTION
## Summary
- configure i18next with a provider and browser language detection
- add French and English translation files
- wrap some text in the home page with the `t` helper

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a1f3df388832f8de7012e69e2da05