### PR TITLE
Fix hydration warning on html element

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body>
         <I18nProvider>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>


### PR DESCRIPTION
## Summary
- suppress hydration mismatch on the `<html>` element to stop console errors

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_685afbf7fed4832fbfd3f28ae3cc88db