### PR TITLE
Add dark mode images for navbar and footer

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -7,8 +7,7 @@ export default function ArticlesPage() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <header
-        className="border-b sticky top-0 z-40 bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-navbar.svg')" }}
+        className="border-b sticky top-0 z-40 bg-cover bg-center bg-[url('/website-navbar.svg')] dark:bg-[url('/darkmode-website-navbar.svg')]"
       >
         <div className="container flex h-20 items-center justify-between py-4">
           <Link href="/" className="flex items-center gap-2">
@@ -160,8 +159,7 @@ export default function ArticlesPage() {
       </main>
 
       <footer
-        className="text-white bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-footer.svg')" }}
+        className="text-white bg-cover bg-center bg-[url('/website-footer.svg')] dark:bg-[url('/darkmode-website-footer.svg')]"
       >
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -10,8 +10,7 @@ export default function ContactPage() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <header
-        className="border-b sticky top-0 z-40 bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-navbar.svg')" }}
+        className="border-b sticky top-0 z-40 bg-cover bg-center bg-[url('/website-navbar.svg')] dark:bg-[url('/darkmode-website-navbar.svg')]"
       >
         <div className="container flex h-20 items-center justify-between py-4">
           <Link href="/" className="flex items-center gap-2">
@@ -316,8 +315,7 @@ export default function ContactPage() {
       />
 
       <footer
-        className="text-white bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-footer.svg')" }}
+        className="text-white bg-cover bg-center bg-[url('/website-footer.svg')] dark:bg-[url('/darkmode-website-footer.svg')]"
       >
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -7,8 +7,7 @@ export default function FaqPage() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <header
-        className="border-b sticky top-0 z-40 bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-navbar.svg')" }}
+        className="border-b sticky top-0 z-40 bg-cover bg-center bg-[url('/website-navbar.svg')] dark:bg-[url('/darkmode-website-navbar.svg')]"
       >
         <div className="container flex h-20 items-center justify-between py-4">
           <Link href="/" className="flex items-center gap-2">
@@ -149,7 +148,7 @@ export default function FaqPage() {
         </section>
       </main>
 
-      <footer className="text-white bg-cover bg-center" style={{ backgroundImage: "url('/website-footer.svg')" }}>
+      <footer className="text-white bg-cover bg-center bg-[url('/website-footer.svg')] dark:bg-[url('/darkmode-website-footer.svg')]">
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">
             <div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,8 +11,7 @@ export default function Home() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <header
-        className="border-b sticky top-0 z-40 bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-navbar.svg')" }}
+        className="border-b sticky top-0 z-40 bg-cover bg-center bg-[url('/website-navbar.svg')] dark:bg-[url('/darkmode-website-navbar.svg')]"
       >
         <div className="container flex h-20 items-center justify-between py-4">
           <Link href="/" className="flex items-center gap-2">
@@ -511,8 +510,7 @@ export default function Home() {
       </div>
 
       <footer
-        className="text-white bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-footer.svg')" }}
+        className="text-white bg-cover bg-center bg-[url('/website-footer.svg')] dark:bg-[url('/darkmode-website-footer.svg')]"
       >
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -7,8 +7,7 @@ export default function PrivacyPolicyPage() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <header
-        className="border-b sticky top-0 z-40 bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-navbar.svg')" }}
+        className="border-b sticky top-0 z-40 bg-cover bg-center bg-[url('/website-navbar.svg')] dark:bg-[url('/darkmode-website-navbar.svg')]"
       >
         <div className="container flex h-20 items-center justify-between py-4">
           <Link href="/" className="flex items-center gap-2">
@@ -94,7 +93,7 @@ export default function PrivacyPolicyPage() {
         </section>
       </main>
 
-      <footer className="text-white bg-cover bg-center" style={{ backgroundImage: "url('/website-footer.svg')" }}>
+      <footer className="text-white bg-cover bg-center bg-[url('/website-footer.svg')] dark:bg-[url('/darkmode-website-footer.svg')]">
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">
             <div>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -7,8 +7,7 @@ export default function ServicesPage() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <header
-        className="border-b sticky top-0 z-40 bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-navbar.svg')" }}
+        className="border-b sticky top-0 z-40 bg-cover bg-center bg-[url('/website-navbar.svg')] dark:bg-[url('/darkmode-website-navbar.svg')]"
       >
         <div className="container flex h-20 items-center justify-between py-4">
           <Link href="/" className="flex items-center gap-2">
@@ -243,8 +242,7 @@ export default function ServicesPage() {
       </main>
 
       <footer
-        className="text-white bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-footer.svg')" }}
+        className="text-white bg-cover bg-center bg-[url('/website-footer.svg')] dark:bg-[url('/darkmode-website-footer.svg')]"
       >
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">

--- a/app/story/page.tsx
+++ b/app/story/page.tsx
@@ -7,8 +7,7 @@ export default function StoryPage() {
   return (
     <div className="flex flex-col min-h-screen bg-background">
       <header
-        className="border-b sticky top-0 z-40 bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-navbar.svg')" }}
+        className="border-b sticky top-0 z-40 bg-cover bg-center bg-[url('/website-navbar.svg')] dark:bg-[url('/darkmode-website-navbar.svg')]"
       >
         <div className="container flex h-20 items-center justify-between py-4">
           <Link href="/" className="flex items-center gap-2">
@@ -173,8 +172,7 @@ export default function StoryPage() {
       </main>
 
       <footer
-        className="text-white bg-cover bg-center"
-        style={{ backgroundImage: "url('/website-footer.svg')" }}
+        className="text-white bg-cover bg-center bg-[url('/website-footer.svg')] dark:bg-[url('/darkmode-website-footer.svg')]"
       >
         <div className="container py-12 px-4 md:px-6">
           <div className="grid gap-8 md:grid-cols-2">


### PR DESCRIPTION
## Summary
- render dark theme images when dark mode is active
- keep existing light theme images for light mode

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_685afe4cd6cc832fbcb1b965eaa52617