### PR TITLE
Update dark mode and fix devtool issues

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,8 @@
+@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&family=Eczar&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&family=Eczar&display=swap");
 
 body {
   font-family: Century, "Cormorant Garamond", Eczar, sans-serif;
@@ -51,7 +51,7 @@ body {
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   .dark {
-    --background: 0 0% 3.9%;
+    --background: 235 11% 23%;
     --foreground: 0 0% 98%;
     --card: 0 0% 3.9%;
     --card-foreground: 0 0% 98%;
@@ -92,5 +92,31 @@ body {
   }
   body {
     @apply bg-background text-foreground;
+  }
+  html {
+    text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+  }
+  body {
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+  }
+  .grid {
+    display: -ms-grid;
+  }
+  .flex {
+    display: -ms-flexbox;
+  }
+  .flex-row {
+    -ms-flex-direction: row;
+  }
+  .flex-col {
+    -ms-flex-direction: column;
+  }
+  .grow {
+    -ms-flex-positive: 1;
+  }
+  .user-select-none {
+    -ms-user-select: none;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -181,6 +181,7 @@ export default function Home() {
                   width={600}
                   height={500}
                   className="rounded-lg object-cover shadow-lg"
+                  style={{ width: "auto", height: "auto" }}
                 />
               </div>
             </div>
@@ -331,6 +332,7 @@ export default function Home() {
             width={1920}
             height={600}
             className="w-full object-cover"
+            style={{ width: "auto", height: "auto" }}
           />
           <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
             <div className="text-center text-white max-w-3xl px-4">
@@ -506,6 +508,7 @@ export default function Home() {
           width={1920}
           height={400}
           className="w-full object-cover"
+          style={{ width: "auto", height: "auto" }}
         />
       </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,8 +1,8 @@
+@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&family=Eczar&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@700&family=Eczar&display=swap");
 
 body {
   font-family: Century, "Cormorant Garamond", Eczar, sans-serif;
@@ -51,7 +51,7 @@ body {
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   .dark {
-    --background: 0 0% 3.9%;
+    --background: 235 11% 23%;
     --foreground: 0 0% 98%;
     --card: 0 0% 3.9%;
     --card-foreground: 0 0% 98%;
@@ -95,5 +95,31 @@ body {
   }
   body {
     @apply bg-background text-foreground;
+  }
+  html {
+    text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+  }
+  body {
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+  }
+  .grid {
+    display: -ms-grid;
+  }
+  .flex {
+    display: -ms-flexbox;
+  }
+  .flex-row {
+    -ms-flex-direction: row;
+  }
+  .flex-col {
+    -ms-flex-direction: column;
+  }
+  .grow {
+    -ms-flex-positive: 1;
+  }
+  .user-select-none {
+    -ms-user-select: none;
   }
 }


### PR DESCRIPTION
## Summary
- move `@import` statements to top of global stylesheets
- tweak dark theme background color
- add browser fallbacks for common CSS features
- ensure placeholder images maintain aspect ratio

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_685b03b40ba8832f80ffcf9dc9b1700c